### PR TITLE
added structured-query param to directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ AngularJS library for working with MarkLogic and Highcharts
 
 #### directives
 
-- `ml-highchart`: accepts highcart configuration object as highchart-config and MLSearch context as ml-search
+- `ml-highchart`: accepts highcart configuration object as highchart-config and MLSearch context as ml-search. Optionally accepts a structured-query object which will replace the search query with the structured query.
 
 #### example
 
@@ -76,4 +76,8 @@ app.js
 html 
 ```html
 <ml-highchart highchart-config="ctrl.highchartConfig" ml-search="ctrl.mlSearch"></ml-highchart>
+```
+html using a structured query 
+```html
+<ml-highchart highchart-config="ctrl.highchartConfig" ml-search="ctrl.mlSearch" structured-query="{'term-query':{'text':['blue']}}"></ml-highchart>
 ```

--- a/src/directives/ml-highchart.directive.js
+++ b/src/directives/ml-highchart.directive.js
@@ -22,13 +22,22 @@
     .directive('mlHighchart', ['$q', 'HighchartsHelper', 'MLRest', 'MLSearchFactory', function($q, HighchartsHelper, MLRest, searchFactory) {
 
       function link(scope, element, attrs) {
+  
         if (!scope.mlSearch) {
           scope.mlSearch = searchFactory.newContext();
         }
+
+        var mlSearch = scope.mlSearch;
+
+        if (scope.structuredQuery) {
+          mlSearch = searchFactory.newContext();
+          mlSearch.addAdditionalQuery(scope.structuredQuery);
+        }
+        
         var loadData = function() {
           if (scope.highchartConfig) {
             HighchartsHelper.chartFromConfig(
-              scope.highchartConfig, scope.mlSearch,
+              scope.highchartConfig, mlSearch,
               scope.callback).then(function(populatedConfig) {
               scope.populatedConfig = populatedConfig;
             });
@@ -50,10 +59,15 @@
           };
         };
 
-        var origSearchFun = scope.mlSearch.search;
-        scope.mlSearch.search = reloadChartsDecorator(origSearchFun);
+        var origSearchFun = mlSearch.search;
+        mlSearch.search = reloadChartsDecorator(origSearchFun);
+
         loadData();
 
+        scope.$watch('structuredQuery', function() {
+          loadData();
+        });
+          
       }
 
       return {
@@ -61,6 +75,7 @@
         templateUrl: '/ml-highcharts/templates/ml-highchart.html',
         scope: {
           'mlSearch': '=',
+          'structuredQuery': '=',
           'highchartConfig': '=',
           'callback': '&'
         },


### PR DESCRIPTION
code changes are just in the directive. I captured scope.mlSearch in a variable and use that for the chart because when there is a structured query we have to override the search but we don't want to change the original search. So that's why a new search context is created when a structured query is used.